### PR TITLE
Git action to create and publish image to ghcr

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,36 @@
+name: Build and Push Docker Image to ghcr.io
+
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Get version
+        id: package
+        run: echo "::set-output name=version::$(node -p "require('./package.json').version")"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: ghcr.io/${{ github.repository }}:${{ steps.package.outputs.version }}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 services:
   local_monday_code_api_server:
     build:
-      context: .
+      context: ghcr.io/DorShakedMonday/apps-sdk-local-server:latest
       dockerfile: Dockerfile
     user: node
     volumes:


### PR DESCRIPTION
This will allow developers to use only the provided `docker-compose.yml` without cloning the repo and building the image on their own